### PR TITLE
Add fetching of FABRID policy descriptions to the SCION CLI. 

### DIFF
--- a/control/cmd/control/main.go
+++ b/control/cmd/control/main.go
@@ -155,7 +155,7 @@ func realMain(ctx context.Context) error {
 	var fabridMgr *fabrid.FabridManager
 	if globalCfg.Fabrid.Enabled {
 		fabridMgr = fabrid.NewFabridManager(topo.InterfaceIDs(),
-			globalCfg.Fabrid.RemoteCacheValidity.Duration)
+			globalCfg.Fabrid.RemoteCacheValidity.Duration, topo.IA())
 		err = fabridMgr.Load(globalCfg.Fabrid.Path)
 		if err != nil {
 			return serrors.WrapStr("initializing FABRID", err)

--- a/control/fabrid/BUILD.bazel
+++ b/control/fabrid/BUILD.bazel
@@ -28,6 +28,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//control/config:go_default_library",
+        "//pkg/private/xtest:go_default_library",
         "//pkg/segment/extensions/fabrid:go_default_library",
         "@com_github_stretchr_testify//require:go_default_library",
     ],

--- a/control/fabrid/fabrid_manager.go
+++ b/control/fabrid/fabrid_manager.go
@@ -47,6 +47,7 @@ type RemoteMap struct {
 type FabridManager struct {
 	autoIncrIndex            int
 	asInterfaceIDs           []uint16
+	IA                       addr.IA
 	SupportedIndicesMap      fabrid_ext.SupportedIndicesMap
 	IndexIdentifierMap       fabrid_ext.IndexIdentifierMap
 	IdentifierDescriptionMap map[uint32]string
@@ -56,12 +57,14 @@ type FabridManager struct {
 	RemoteCacheValidity      time.Duration
 }
 
-func NewFabridManager(asInterfaceIDs []uint16, remoteCacheValidity time.Duration) *FabridManager {
+func NewFabridManager(asInterfaceIDs []uint16, remoteCacheValidity time.Duration,
+	ia addr.IA) *FabridManager {
 	fb := &FabridManager{
 		SupportedIndicesMap:      map[fabrid_ext.ConnectionPair][]uint8{},
 		IndexIdentifierMap:       map[uint8]*fabrid_ext.PolicyIdentifier{},
 		IdentifierDescriptionMap: map[uint32]string{},
 		MPLSMap:                  NewMplsMaps(),
+		IA:                       ia,
 		RemotePolicyCache:        map[RemotePolicyIdentifier]RemotePolicyDescription{},
 		RemoteMapsCache:          map[addr.IA]RemoteMap{},
 		RemoteCacheValidity:      remoteCacheValidity,

--- a/control/fabrid/fabrid_manager_test.go
+++ b/control/fabrid/fabrid_manager_test.go
@@ -22,17 +22,18 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/scionproto/scion/control/config"
+	"github.com/scionproto/scion/pkg/private/xtest"
 	"github.com/scionproto/scion/pkg/segment/extensions/fabrid"
 )
 
 func TestLoadInvalidPolicies(t *testing.T) {
-	fm := NewFabridManager([]uint16{1, 2}, 5*time.Second)
+	fm := NewFabridManager([]uint16{1, 2}, 5*time.Second, xtest.MustParseIA("1-ff00:0:111"))
 	err := fm.Load("testdata/mixed")
 	require.ErrorContains(t, err, "Unable to parse policy")
 }
 
 func TestLoadPolicyWithNonExistingInterfaces(t *testing.T) {
-	fm := NewFabridManager([]uint16{1}, 5*time.Second)
+	fm := NewFabridManager([]uint16{1}, 5*time.Second, xtest.MustParseIA("1-ff00:0:111"))
 	err := fm.Load("testdata/correct")
 	require.ErrorContains(t, err, "Interface does not exist")
 }
@@ -118,7 +119,7 @@ func TestLoadPolicies(t *testing.T) {
 		},
 	}
 
-	fm := NewFabridManager([]uint16{1, 2}, 5*time.Second)
+	fm := NewFabridManager([]uint16{1, 2}, 5*time.Second, xtest.MustParseIA("1-ff00:0:111"))
 	fm.autoIncrIndex = 1
 	err := fm.Load("testdata/correct")
 	require.NoError(t, err)
@@ -239,7 +240,8 @@ func TestAddPolicy(t *testing.T) {
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			fm := NewFabridManager([]uint16{3, 5, 7}, 5*time.Second)
+			fm := NewFabridManager([]uint16{3, 5, 7}, 5*time.Second,
+				xtest.MustParseIA("1-ff00:0:111"))
 			oldIndex := fm.autoIncrIndex
 			err := fm.addPolicy(&tc.Policy)
 			newIndex := fm.autoIncrIndex

--- a/daemon/BUILD.bazel
+++ b/daemon/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/scionproto/scion/daemon",
     visibility = ["//visibility:public"],
     deps = [
+        "//daemon/config:go_default_library",
         "//daemon/drkey:go_default_library",
         "//daemon/fetcher:go_default_library",
         "//daemon/internal/servers:go_default_library",

--- a/daemon/cmd/daemon/main.go
+++ b/daemon/cmd/daemon/main.go
@@ -271,6 +271,7 @@ func realMain(ctx context.Context) error {
 			IA:       topo.IA(),
 			MTU:      topo.MTU(),
 			Topology: topo,
+			Cfg:      globalCfg.SD,
 			Fetcher: fetcher.NewFetcher(
 				fetcher.FetcherConfig{
 					IA:         topo.IA(),

--- a/daemon/config/config.go
+++ b/daemon/config/config.go
@@ -131,6 +131,8 @@ type SDConfig struct {
 	// If HiddenPathGroups begins with http:// or https://, it will be fetched
 	// over the network from the specified URL instead.
 	HiddenPathGroups string `toml:"hidden_path_groups,omitempty"`
+	// FabridGlobalPolicyStore specifies the URL to the mapping of FABRID policies to descriptions.
+	FabridGlobalPolicyStore string `toml:"fabrid_global_policy_store,omitempty"`
 }
 
 func (cfg *SDConfig) InitDefaults() {
@@ -139,6 +141,9 @@ func (cfg *SDConfig) InitDefaults() {
 	}
 	if cfg.QueryInterval.Duration == 0 {
 		cfg.QueryInterval.Duration = DefaultQueryInterval
+	}
+	if cfg.FabridGlobalPolicyStore == "" {
+		cfg.FabridGlobalPolicyStore = daemon.DefaultFabridGlobalPolicyStore
 	}
 }
 

--- a/daemon/config/sample.go
+++ b/daemon/config/sample.go
@@ -29,4 +29,8 @@ query_interval = "5m"
 
 # The configuration containing hidden path groups. (default "")
 hidden_path_groups =  ""
+
+# The main URL to the mapping of FABRID policies to descriptions. (default https://raw.
+# githubusercontent.com/jeltevanbommel/fabrid-policies/refs/heads/main/)
+fabrid_global_policy_store = ""
 `

--- a/daemon/config/sample.go
+++ b/daemon/config/sample.go
@@ -31,6 +31,6 @@ query_interval = "5m"
 hidden_path_groups =  ""
 
 # The main URL to the mapping of FABRID policies to descriptions. (default https://raw.
-# githubusercontent.com/jeltevanbommel/fabrid-policies/refs/heads/main/)
+# githubusercontent.com/netsec-ethz/scionlab-fabrid-policies/refs/heads/master/policies/)
 fabrid_global_policy_store = ""
 `

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -25,6 +25,7 @@ import (
 	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/prometheus/client_golang/prometheus"
 
+	"github.com/scionproto/scion/daemon/config"
 	"github.com/scionproto/scion/daemon/drkey"
 	"github.com/scionproto/scion/daemon/fetcher"
 	"github.com/scionproto/scion/daemon/internal/servers"
@@ -115,6 +116,7 @@ type ServerConfig struct {
 	Topology    servers.Topology
 	DRKeyClient *drkey.ClientEngine
 	Dialer      libgrpc.Dialer
+	Cfg         config.SDConfig
 }
 
 // NewServer constructs a daemon API server.
@@ -125,12 +127,13 @@ func NewServer(cfg ServerConfig) *servers.DaemonServer {
 		// TODO(JordiSubira): This will be changed in the future to fetch
 		// the information from the CS instead of feeding the configuration
 		// file into.
-		Topology:    cfg.Topology,
-		Fetcher:     cfg.Fetcher,
-		ASInspector: cfg.Engine.Inspector,
-		RevCache:    cfg.RevCache,
-		DRKeyClient: cfg.DRKeyClient,
-		Dialer:      cfg.Dialer,
+		FabridGlobalPolicyStore: cfg.Cfg.FabridGlobalPolicyStore,
+		Topology:                cfg.Topology,
+		Fetcher:                 cfg.Fetcher,
+		ASInspector:             cfg.Engine.Inspector,
+		RevCache:                cfg.RevCache,
+		DRKeyClient:             cfg.DRKeyClient,
+		Dialer:                  cfg.Dialer,
 		Metrics: servers.Metrics{
 			PathsRequests: servers.RequestMetrics{
 				Requests: metrics.NewPromCounterFrom(prometheus.CounterOpts{

--- a/daemon/internal/servers/grpc.go
+++ b/daemon/internal/servers/grpc.go
@@ -56,15 +56,16 @@ type Topology interface {
 
 // DaemonServer handles gRPC requests to the SCION daemon.
 type DaemonServer struct {
-	IA          addr.IA
-	MTU         uint16
-	Topology    Topology
-	Fetcher     fetcher.Fetcher
-	RevCache    revcache.RevCache
-	ASInspector trust.Inspector
-	DRKeyClient *drkey_daemon.ClientEngine
-	Dialer      libgrpc.Dialer
-	Metrics     Metrics
+	IA                      addr.IA
+	MTU                     uint16
+	Topology                Topology
+	Fetcher                 fetcher.Fetcher
+	RevCache                revcache.RevCache
+	ASInspector             trust.Inspector
+	DRKeyClient             *drkey_daemon.ClientEngine
+	Dialer                  libgrpc.Dialer
+	Metrics                 Metrics
+	FabridGlobalPolicyStore string
 
 	foregroundPathDedupe singleflight.Group
 	backgroundPathDedupe singleflight.Group

--- a/daemon/internal/servers/grpc_fabrid.go
+++ b/daemon/internal/servers/grpc_fabrid.go
@@ -16,6 +16,10 @@ package servers
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
 	"time"
 
 	timestamppb "github.com/golang/protobuf/ptypes/timestamp"
@@ -197,4 +201,77 @@ func (s *DaemonServer) FabridKeys(ctx context.Context, req *sdpb.FabridKeysReque
 		AsHostKeys:  fabridKeys,
 		HostHostKey: hostHostKey,
 	}, nil
+}
+
+func (s *DaemonServer) PolicyDescription(ctx context.Context,
+	request *sdpb.PolicyDescriptionRequest) (
+	*sdpb.PolicyDescriptionResponse, error) {
+
+	var description string
+	if request.IsLocal {
+		conn, err := s.Dialer.Dial(ctx, &snet.SVCAddr{SVC: addr.SvcCS})
+		if err != nil {
+			log.FromCtx(ctx).Debug("Dialing CS failed", "err", err)
+		}
+		defer conn.Close()
+		client := experimental.NewFABRIDIntraServiceClient(conn)
+		response, err := client.RemotePolicyDescription(ctx,
+			&experimental.RemotePolicyDescriptionRequest{
+				PolicyIdentifier: request.PolicyIdentifier,
+				IsdAs:            request.IsdAs,
+			})
+		if err != nil {
+			return &sdpb.PolicyDescriptionResponse{}, err
+		}
+		description = response.Description
+	} else {
+		globalPolicyURL := fmt.Sprintf(s.FabridGlobalPolicyStore+"/%d.json",
+			request.PolicyIdentifier)
+
+		// Fetch the global policy from the URL
+		policy, err := FetchGlobalPolicy(globalPolicyURL)
+		if err != nil {
+			return nil, serrors.WrapStr("fetching global policy", err)
+		}
+		// Grab the description from the fetched policy
+		if policy != nil {
+			description = policy.Description
+		}
+	}
+	return &sdpb.PolicyDescriptionResponse{Description: description}, nil
+}
+
+// GlobalPolicy holds a mapping of uint32 identifiers to their string descriptions
+type GlobalPolicy struct {
+	Description string `json:"description"`
+}
+
+// FetchGlobalPolicy fetches and parses the global policy from the given URL
+func FetchGlobalPolicy(url string) (*GlobalPolicy, error) {
+	resp, err := http.Get(url)
+	if err != nil {
+		return nil, serrors.WrapStr("failed to fetch global policy", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		if resp.StatusCode == http.StatusNotFound {
+			return nil, serrors.New("global policy not found")
+		}
+		return nil, serrors.New("failed to fetch global policy", "StatusCode", resp.StatusCode)
+	}
+
+	// Read the response body
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, serrors.WrapStr("failed to read response body", err)
+	}
+
+	// Unmarshal the JSON data into a map
+	var policy GlobalPolicy
+	if err = json.Unmarshal(body, &policy); err != nil {
+		return nil, serrors.WrapStr("failed to unmarshal policy JSON", err)
+	}
+
+	return &policy, nil
 }

--- a/doc/command/scion/scion.rst
+++ b/doc/command/scion/scion.rst
@@ -25,6 +25,7 @@ SEE ALSO
 
 * :ref:`scion address <scion_address>` 	 - Show (one of) this host's SCION address(es)
 * :ref:`scion completion <scion_completion>` 	 - Generate the autocompletion script for the specified shell
+* :ref:`scion fabrid <scion_fabrid>` 	 - Display FABRID policy information
 * :ref:`scion ping <scion_ping>` 	 - Test connectivity to a remote SCION host using SCMP echo packets
 * :ref:`scion showpaths <scion_showpaths>` 	 - Display paths to a SCION AS
 * :ref:`scion traceroute <scion_traceroute>` 	 - Trace the SCION route to a remote SCION AS using SCMP traceroute packets

--- a/doc/command/scion/scion_fabrid.rst
+++ b/doc/command/scion/scion_fabrid.rst
@@ -1,0 +1,48 @@
+:orphan:
+
+.. _scion_fabrid:
+
+scion fabrid
+------------
+
+Display FABRID policy information
+
+Synopsis
+~~~~~~~~
+
+
+'fabrid' fetches the description of a global or local FABRID policy.
+
+::
+
+  scion fabrid identifier [remote_as] [flags]
+
+Examples
+~~~~~~~~
+
+::
+
+    scion fabrid G1001
+    scion fabrid L1101 1-ff00:0:110
+    scion fabrid L1101 1-ff00:0:110 --log.level debug'
+
+Options
+~~~~~~~
+
+::
+
+      --format string          Specify the output format (human|json|yaml) (default "human")
+  -h, --help                   help for fabrid
+      --isd-as isd-as          The local ISD-AS to use. (default 0-0)
+  -l, --local ip               Local IP address to listen on. (default invalid IP)
+      --log.level string       Console logging level verbosity (debug|info|error)
+      --no-color               disable colored output
+      --sciond string          SCION Daemon address. (default "127.0.0.1:30255")
+      --timeout duration       Timeout (default 5s)
+      --tracing.agent string   Tracing agent address
+
+SEE ALSO
+~~~~~~~~
+
+* :ref:`scion <scion>` 	 - SCION networking utilities.
+

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -39,6 +39,9 @@ const (
 	DefaultAPIAddress = "127.0.0.1:30255"
 	// DefaultAPIPort contains the default port for a daemon client API socket.
 	DefaultAPIPort = 30255
+	// DefaultFabridGlobalPolicyStore contains the default FABRID path policy store.
+	DefaultFabridGlobalPolicyStore = "https://raw.githubusercontent." +
+		"com/jeltevanbommel/fabrid-policies/refs/heads/main/"
 )
 
 // NewService returns a SCION Daemon API connection factory.
@@ -90,6 +93,9 @@ type Connector interface {
 	DRKeyGetHostHostKey(ctx context.Context, meta drkey.HostHostMeta) (drkey.HostHostKey, error)
 	// FabridKeys requests FABRID DRKeys for all provided ASes and the path validation key
 	FabridKeys(ctx context.Context, meta drkey.FabridKeysMeta) (drkey.FabridKeysResponse, error)
+	// PolicyDescription requests the string description for a FABRID policy
+	PolicyDescription(ctx context.Context, isLocal bool, identifier uint32,
+		ia *addr.IA) (string, error)
 	// Close shuts down the connection to the daemon.
 	Close() error
 }

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -41,7 +41,7 @@ const (
 	DefaultAPIPort = 30255
 	// DefaultFabridGlobalPolicyStore contains the default FABRID path policy store.
 	DefaultFabridGlobalPolicyStore = "https://raw.githubusercontent." +
-		"com/jeltevanbommel/fabrid-policies/refs/heads/main/"
+		"com/netsec-ethz/scionlab-fabrid-policies/refs/heads/master/policies/"
 )
 
 // NewService returns a SCION Daemon API connection factory.

--- a/pkg/daemon/grpc_fabrid.go
+++ b/pkg/daemon/grpc_fabrid.go
@@ -17,6 +17,7 @@ package daemon
 import (
 	"context"
 
+	"github.com/scionproto/scion/pkg/addr"
 	"github.com/scionproto/scion/pkg/drkey"
 	"github.com/scionproto/scion/pkg/experimental/fabrid"
 	sdpb "github.com/scionproto/scion/pkg/proto/daemon"
@@ -90,4 +91,22 @@ func (c grpcConn) FabridKeys(ctx context.Context, meta drkey.FabridKeysMeta,
 		ASHostKeys: asHostKeys,
 		PathKey:    hostHostKey,
 	}, nil
+}
+
+func (c grpcConn) PolicyDescription(ctx context.Context,
+	isLocal bool, identifier uint32, ia *addr.IA) (string, error) {
+
+	client := sdpb.NewDaemonServiceClient(c.conn)
+	request := &sdpb.PolicyDescriptionRequest{
+		IsLocal:          isLocal,
+		PolicyIdentifier: identifier,
+	}
+	if isLocal {
+		request.IsdAs = uint64(*ia)
+	}
+	response, err := client.PolicyDescription(ctx, request)
+	if err != nil {
+		return "", err
+	}
+	return response.Description, nil
 }

--- a/pkg/proto/daemon/daemon.pb.go
+++ b/pkg/proto/daemon/daemon.pb.go
@@ -1805,7 +1805,7 @@ var file_proto_daemon_v1_daemon_proto_rawDesc = []byte{
 	0x49, 0x52, 0x45, 0x43, 0x54, 0x10, 0x01, 0x12, 0x17, 0x0a, 0x13, 0x4c, 0x49, 0x4e, 0x4b, 0x5f,
 	0x54, 0x59, 0x50, 0x45, 0x5f, 0x4d, 0x55, 0x4c, 0x54, 0x49, 0x5f, 0x48, 0x4f, 0x50, 0x10, 0x02,
 	0x12, 0x16, 0x0a, 0x12, 0x4c, 0x49, 0x4e, 0x4b, 0x5f, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x4f, 0x50,
-	0x45, 0x4e, 0x5f, 0x4e, 0x45, 0x54, 0x10, 0x03, 0x32, 0xf8, 0x06, 0x0a, 0x0d, 0x44, 0x61, 0x65,
+	0x45, 0x4e, 0x5f, 0x4e, 0x45, 0x54, 0x10, 0x03, 0x32, 0xe6, 0x07, 0x0a, 0x0d, 0x44, 0x61, 0x65,
 	0x6d, 0x6f, 0x6e, 0x53, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x12, 0x48, 0x0a, 0x05, 0x50, 0x61,
 	0x74, 0x68, 0x73, 0x12, 0x1d, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x2e, 0x64, 0x61, 0x65, 0x6d,
 	0x6f, 0x6e, 0x2e, 0x76, 0x31, 0x2e, 0x50, 0x61, 0x74, 0x68, 0x73, 0x52, 0x65, 0x71, 0x75, 0x65,
@@ -1861,10 +1861,17 @@ var file_proto_daemon_v1_daemon_proto_rawDesc = []byte{
 	0x64, 0x4b, 0x65, 0x79, 0x73, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x1a, 0x23, 0x2e, 0x70,
 	0x72, 0x6f, 0x74, 0x6f, 0x2e, 0x64, 0x61, 0x65, 0x6d, 0x6f, 0x6e, 0x2e, 0x76, 0x31, 0x2e, 0x46,
 	0x61, 0x62, 0x72, 0x69, 0x64, 0x4b, 0x65, 0x79, 0x73, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73,
-	0x65, 0x22, 0x00, 0x42, 0x2e, 0x5a, 0x2c, 0x67, 0x69, 0x74, 0x68, 0x75, 0x62, 0x2e, 0x63, 0x6f,
-	0x6d, 0x2f, 0x73, 0x63, 0x69, 0x6f, 0x6e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x2f, 0x73, 0x63, 0x69,
-	0x6f, 0x6e, 0x2f, 0x70, 0x6b, 0x67, 0x2f, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x2f, 0x64, 0x61, 0x65,
-	0x6d, 0x6f, 0x6e, 0x62, 0x06, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x33,
+	0x65, 0x22, 0x00, 0x12, 0x6c, 0x0a, 0x11, 0x50, 0x6f, 0x6c, 0x69, 0x63, 0x79, 0x44, 0x65, 0x73,
+	0x63, 0x72, 0x69, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x12, 0x29, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f,
+	0x2e, 0x64, 0x61, 0x65, 0x6d, 0x6f, 0x6e, 0x2e, 0x76, 0x31, 0x2e, 0x50, 0x6f, 0x6c, 0x69, 0x63,
+	0x79, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x52, 0x65, 0x71, 0x75,
+	0x65, 0x73, 0x74, 0x1a, 0x2a, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x2e, 0x64, 0x61, 0x65, 0x6d,
+	0x6f, 0x6e, 0x2e, 0x76, 0x31, 0x2e, 0x50, 0x6f, 0x6c, 0x69, 0x63, 0x79, 0x44, 0x65, 0x73, 0x63,
+	0x72, 0x69, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x22,
+	0x00, 0x42, 0x2e, 0x5a, 0x2c, 0x67, 0x69, 0x74, 0x68, 0x75, 0x62, 0x2e, 0x63, 0x6f, 0x6d, 0x2f,
+	0x73, 0x63, 0x69, 0x6f, 0x6e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x2f, 0x73, 0x63, 0x69, 0x6f, 0x6e,
+	0x2f, 0x70, 0x6b, 0x67, 0x2f, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x2f, 0x64, 0x61, 0x65, 0x6d, 0x6f,
+	0x6e, 0x62, 0x06, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x33,
 }
 
 var (
@@ -1916,7 +1923,9 @@ var file_proto_daemon_v1_daemon_proto_goTypes = []interface{}{
 	(drkey.Protocol)(0),                 // 31: proto.drkey.v1.Protocol
 	(*emptypb.Empty)(nil),               // 32: google.protobuf.Empty
 	(*FabridKeysRequest)(nil),           // 33: proto.daemon.v1.FabridKeysRequest
-	(*FabridKeysResponse)(nil),          // 34: proto.daemon.v1.FabridKeysResponse
+	(*PolicyDescriptionRequest)(nil),    // 34: proto.daemon.v1.PolicyDescriptionRequest
+	(*FabridKeysResponse)(nil),          // 35: proto.daemon.v1.FabridKeysResponse
+	(*PolicyDescriptionResponse)(nil),   // 36: proto.daemon.v1.PolicyDescriptionResponse
 }
 var file_proto_daemon_v1_daemon_proto_depIdxs = []int32{
 	3,  // 0: proto.daemon.v1.PathsResponse.paths:type_name -> proto.daemon.v1.Path
@@ -1956,18 +1965,20 @@ var file_proto_daemon_v1_daemon_proto_depIdxs = []int32{
 	20, // 34: proto.daemon.v1.DaemonService.DRKeyHostAS:input_type -> proto.daemon.v1.DRKeyHostASRequest
 	24, // 35: proto.daemon.v1.DaemonService.DRKeyHostHost:input_type -> proto.daemon.v1.DRKeyHostHostRequest
 	33, // 36: proto.daemon.v1.DaemonService.FabridKeys:input_type -> proto.daemon.v1.FabridKeysRequest
-	2,  // 37: proto.daemon.v1.DaemonService.Paths:output_type -> proto.daemon.v1.PathsResponse
-	8,  // 38: proto.daemon.v1.DaemonService.AS:output_type -> proto.daemon.v1.ASResponse
-	10, // 39: proto.daemon.v1.DaemonService.Interfaces:output_type -> proto.daemon.v1.InterfacesResponse
-	13, // 40: proto.daemon.v1.DaemonService.Services:output_type -> proto.daemon.v1.ServicesResponse
-	18, // 41: proto.daemon.v1.DaemonService.NotifyInterfaceDown:output_type -> proto.daemon.v1.NotifyInterfaceDownResponse
-	19, // 42: proto.daemon.v1.DaemonService.PortRange:output_type -> proto.daemon.v1.PortRangeResponse
-	23, // 43: proto.daemon.v1.DaemonService.DRKeyASHost:output_type -> proto.daemon.v1.DRKeyASHostResponse
-	21, // 44: proto.daemon.v1.DaemonService.DRKeyHostAS:output_type -> proto.daemon.v1.DRKeyHostASResponse
-	25, // 45: proto.daemon.v1.DaemonService.DRKeyHostHost:output_type -> proto.daemon.v1.DRKeyHostHostResponse
-	34, // 46: proto.daemon.v1.DaemonService.FabridKeys:output_type -> proto.daemon.v1.FabridKeysResponse
-	37, // [37:47] is the sub-list for method output_type
-	27, // [27:37] is the sub-list for method input_type
+	34, // 37: proto.daemon.v1.DaemonService.PolicyDescription:input_type -> proto.daemon.v1.PolicyDescriptionRequest
+	2,  // 38: proto.daemon.v1.DaemonService.Paths:output_type -> proto.daemon.v1.PathsResponse
+	8,  // 39: proto.daemon.v1.DaemonService.AS:output_type -> proto.daemon.v1.ASResponse
+	10, // 40: proto.daemon.v1.DaemonService.Interfaces:output_type -> proto.daemon.v1.InterfacesResponse
+	13, // 41: proto.daemon.v1.DaemonService.Services:output_type -> proto.daemon.v1.ServicesResponse
+	18, // 42: proto.daemon.v1.DaemonService.NotifyInterfaceDown:output_type -> proto.daemon.v1.NotifyInterfaceDownResponse
+	19, // 43: proto.daemon.v1.DaemonService.PortRange:output_type -> proto.daemon.v1.PortRangeResponse
+	23, // 44: proto.daemon.v1.DaemonService.DRKeyASHost:output_type -> proto.daemon.v1.DRKeyASHostResponse
+	21, // 45: proto.daemon.v1.DaemonService.DRKeyHostAS:output_type -> proto.daemon.v1.DRKeyHostASResponse
+	25, // 46: proto.daemon.v1.DaemonService.DRKeyHostHost:output_type -> proto.daemon.v1.DRKeyHostHostResponse
+	35, // 47: proto.daemon.v1.DaemonService.FabridKeys:output_type -> proto.daemon.v1.FabridKeysResponse
+	36, // 48: proto.daemon.v1.DaemonService.PolicyDescription:output_type -> proto.daemon.v1.PolicyDescriptionResponse
+	38, // [38:49] is the sub-list for method output_type
+	27, // [27:38] is the sub-list for method input_type
 	27, // [27:27] is the sub-list for extension type_name
 	27, // [27:27] is the sub-list for extension extendee
 	0,  // [0:27] is the sub-list for field type_name
@@ -2324,6 +2335,7 @@ type DaemonServiceClient interface {
 	DRKeyHostAS(ctx context.Context, in *DRKeyHostASRequest, opts ...grpc.CallOption) (*DRKeyHostASResponse, error)
 	DRKeyHostHost(ctx context.Context, in *DRKeyHostHostRequest, opts ...grpc.CallOption) (*DRKeyHostHostResponse, error)
 	FabridKeys(ctx context.Context, in *FabridKeysRequest, opts ...grpc.CallOption) (*FabridKeysResponse, error)
+	PolicyDescription(ctx context.Context, in *PolicyDescriptionRequest, opts ...grpc.CallOption) (*PolicyDescriptionResponse, error)
 }
 
 type daemonServiceClient struct {
@@ -2424,6 +2436,15 @@ func (c *daemonServiceClient) FabridKeys(ctx context.Context, in *FabridKeysRequ
 	return out, nil
 }
 
+func (c *daemonServiceClient) PolicyDescription(ctx context.Context, in *PolicyDescriptionRequest, opts ...grpc.CallOption) (*PolicyDescriptionResponse, error) {
+	out := new(PolicyDescriptionResponse)
+	err := c.cc.Invoke(ctx, "/proto.daemon.v1.DaemonService/PolicyDescription", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // DaemonServiceServer is the server API for DaemonService service.
 type DaemonServiceServer interface {
 	Paths(context.Context, *PathsRequest) (*PathsResponse, error)
@@ -2436,6 +2457,7 @@ type DaemonServiceServer interface {
 	DRKeyHostAS(context.Context, *DRKeyHostASRequest) (*DRKeyHostASResponse, error)
 	DRKeyHostHost(context.Context, *DRKeyHostHostRequest) (*DRKeyHostHostResponse, error)
 	FabridKeys(context.Context, *FabridKeysRequest) (*FabridKeysResponse, error)
+	PolicyDescription(context.Context, *PolicyDescriptionRequest) (*PolicyDescriptionResponse, error)
 }
 
 // UnimplementedDaemonServiceServer can be embedded to have forward compatible implementations.
@@ -2471,6 +2493,9 @@ func (*UnimplementedDaemonServiceServer) DRKeyHostHost(context.Context, *DRKeyHo
 }
 func (*UnimplementedDaemonServiceServer) FabridKeys(context.Context, *FabridKeysRequest) (*FabridKeysResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method FabridKeys not implemented")
+}
+func (*UnimplementedDaemonServiceServer) PolicyDescription(context.Context, *PolicyDescriptionRequest) (*PolicyDescriptionResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method PolicyDescription not implemented")
 }
 
 func RegisterDaemonServiceServer(s *grpc.Server, srv DaemonServiceServer) {
@@ -2657,6 +2682,24 @@ func _DaemonService_FabridKeys_Handler(srv interface{}, ctx context.Context, dec
 	return interceptor(ctx, in, info, handler)
 }
 
+func _DaemonService_PolicyDescription_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(PolicyDescriptionRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(DaemonServiceServer).PolicyDescription(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/proto.daemon.v1.DaemonService/PolicyDescription",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(DaemonServiceServer).PolicyDescription(ctx, req.(*PolicyDescriptionRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 var _DaemonService_serviceDesc = grpc.ServiceDesc{
 	ServiceName: "proto.daemon.v1.DaemonService",
 	HandlerType: (*DaemonServiceServer)(nil),
@@ -2700,6 +2743,10 @@ var _DaemonService_serviceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "FabridKeys",
 			Handler:    _DaemonService_FabridKeys_Handler,
+		},
+		{
+			MethodName: "PolicyDescription",
+			Handler:    _DaemonService_PolicyDescription_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/pkg/proto/daemon/daemon_fabrid.pb.go
+++ b/pkg/proto/daemon/daemon_fabrid.pb.go
@@ -337,6 +337,116 @@ func (x *FabridKeysResponse) GetHostHostKey() *FabridKeyResponse {
 	return nil
 }
 
+type PolicyDescriptionRequest struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	IsLocal          bool   `protobuf:"varint,1,opt,name=is_local,json=isLocal,proto3" json:"is_local,omitempty"`
+	PolicyIdentifier uint32 `protobuf:"varint,2,opt,name=policy_identifier,json=policyIdentifier,proto3" json:"policy_identifier,omitempty"`
+	IsdAs            uint64 `protobuf:"varint,3,opt,name=isd_as,json=isdAs,proto3" json:"isd_as,omitempty"`
+}
+
+func (x *PolicyDescriptionRequest) Reset() {
+	*x = PolicyDescriptionRequest{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_proto_daemon_v1_daemon_fabrid_proto_msgTypes[5]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *PolicyDescriptionRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PolicyDescriptionRequest) ProtoMessage() {}
+
+func (x *PolicyDescriptionRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_proto_daemon_v1_daemon_fabrid_proto_msgTypes[5]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PolicyDescriptionRequest.ProtoReflect.Descriptor instead.
+func (*PolicyDescriptionRequest) Descriptor() ([]byte, []int) {
+	return file_proto_daemon_v1_daemon_fabrid_proto_rawDescGZIP(), []int{5}
+}
+
+func (x *PolicyDescriptionRequest) GetIsLocal() bool {
+	if x != nil {
+		return x.IsLocal
+	}
+	return false
+}
+
+func (x *PolicyDescriptionRequest) GetPolicyIdentifier() uint32 {
+	if x != nil {
+		return x.PolicyIdentifier
+	}
+	return 0
+}
+
+func (x *PolicyDescriptionRequest) GetIsdAs() uint64 {
+	if x != nil {
+		return x.IsdAs
+	}
+	return 0
+}
+
+type PolicyDescriptionResponse struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	Description string `protobuf:"bytes,1,opt,name=description,proto3" json:"description,omitempty"`
+}
+
+func (x *PolicyDescriptionResponse) Reset() {
+	*x = PolicyDescriptionResponse{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_proto_daemon_v1_daemon_fabrid_proto_msgTypes[6]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *PolicyDescriptionResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PolicyDescriptionResponse) ProtoMessage() {}
+
+func (x *PolicyDescriptionResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_proto_daemon_v1_daemon_fabrid_proto_msgTypes[6]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PolicyDescriptionResponse.ProtoReflect.Descriptor instead.
+func (*PolicyDescriptionResponse) Descriptor() ([]byte, []int) {
+	return file_proto_daemon_v1_daemon_fabrid_proto_rawDescGZIP(), []int{6}
+}
+
+func (x *PolicyDescriptionResponse) GetDescription() string {
+	if x != nil {
+		return x.Description
+	}
+	return ""
+}
+
 var File_proto_daemon_v1_daemon_fabrid_proto protoreflect.FileDescriptor
 
 var file_proto_daemon_v1_daemon_fabrid_proto_rawDesc = []byte{
@@ -399,10 +509,22 @@ var file_proto_daemon_v1_daemon_fabrid_proto_rawDesc = []byte{
 	0x2e, 0x46, 0x61, 0x62, 0x72, 0x69, 0x64, 0x4b, 0x65, 0x79, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e,
 	0x73, 0x65, 0x48, 0x00, 0x52, 0x0b, 0x68, 0x6f, 0x73, 0x74, 0x48, 0x6f, 0x73, 0x74, 0x4b, 0x65,
 	0x79, 0x88, 0x01, 0x01, 0x42, 0x10, 0x0a, 0x0e, 0x5f, 0x68, 0x6f, 0x73, 0x74, 0x5f, 0x68, 0x6f,
-	0x73, 0x74, 0x5f, 0x6b, 0x65, 0x79, 0x42, 0x2e, 0x5a, 0x2c, 0x67, 0x69, 0x74, 0x68, 0x75, 0x62,
-	0x2e, 0x63, 0x6f, 0x6d, 0x2f, 0x73, 0x63, 0x69, 0x6f, 0x6e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x2f,
-	0x73, 0x63, 0x69, 0x6f, 0x6e, 0x2f, 0x70, 0x6b, 0x67, 0x2f, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x2f,
-	0x64, 0x61, 0x65, 0x6d, 0x6f, 0x6e, 0x62, 0x06, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x33,
+	0x73, 0x74, 0x5f, 0x6b, 0x65, 0x79, 0x22, 0x79, 0x0a, 0x18, 0x50, 0x6f, 0x6c, 0x69, 0x63, 0x79,
+	0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x52, 0x65, 0x71, 0x75, 0x65,
+	0x73, 0x74, 0x12, 0x19, 0x0a, 0x08, 0x69, 0x73, 0x5f, 0x6c, 0x6f, 0x63, 0x61, 0x6c, 0x18, 0x01,
+	0x20, 0x01, 0x28, 0x08, 0x52, 0x07, 0x69, 0x73, 0x4c, 0x6f, 0x63, 0x61, 0x6c, 0x12, 0x2b, 0x0a,
+	0x11, 0x70, 0x6f, 0x6c, 0x69, 0x63, 0x79, 0x5f, 0x69, 0x64, 0x65, 0x6e, 0x74, 0x69, 0x66, 0x69,
+	0x65, 0x72, 0x18, 0x02, 0x20, 0x01, 0x28, 0x0d, 0x52, 0x10, 0x70, 0x6f, 0x6c, 0x69, 0x63, 0x79,
+	0x49, 0x64, 0x65, 0x6e, 0x74, 0x69, 0x66, 0x69, 0x65, 0x72, 0x12, 0x15, 0x0a, 0x06, 0x69, 0x73,
+	0x64, 0x5f, 0x61, 0x73, 0x18, 0x03, 0x20, 0x01, 0x28, 0x04, 0x52, 0x05, 0x69, 0x73, 0x64, 0x41,
+	0x73, 0x22, 0x3d, 0x0a, 0x19, 0x50, 0x6f, 0x6c, 0x69, 0x63, 0x79, 0x44, 0x65, 0x73, 0x63, 0x72,
+	0x69, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x12, 0x20,
+	0x0a, 0x0b, 0x64, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x18, 0x01, 0x20,
+	0x01, 0x28, 0x09, 0x52, 0x0b, 0x64, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x69, 0x6f, 0x6e,
+	0x42, 0x2e, 0x5a, 0x2c, 0x67, 0x69, 0x74, 0x68, 0x75, 0x62, 0x2e, 0x63, 0x6f, 0x6d, 0x2f, 0x73,
+	0x63, 0x69, 0x6f, 0x6e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x2f, 0x73, 0x63, 0x69, 0x6f, 0x6e, 0x2f,
+	0x70, 0x6b, 0x67, 0x2f, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x2f, 0x64, 0x61, 0x65, 0x6d, 0x6f, 0x6e,
+	0x62, 0x06, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x33,
 }
 
 var (
@@ -417,21 +539,23 @@ func file_proto_daemon_v1_daemon_fabrid_proto_rawDescGZIP() []byte {
 	return file_proto_daemon_v1_daemon_fabrid_proto_rawDescData
 }
 
-var file_proto_daemon_v1_daemon_fabrid_proto_msgTypes = make([]protoimpl.MessageInfo, 5)
+var file_proto_daemon_v1_daemon_fabrid_proto_msgTypes = make([]protoimpl.MessageInfo, 7)
 var file_proto_daemon_v1_daemon_fabrid_proto_goTypes = []interface{}{
 	(*FabridInfo)(nil),                          // 0: proto.daemon.v1.FabridInfo
 	(*FabridPolicy)(nil),                        // 1: proto.daemon.v1.FabridPolicy
 	(*FabridKeysRequest)(nil),                   // 2: proto.daemon.v1.FabridKeysRequest
 	(*FabridKeyResponse)(nil),                   // 3: proto.daemon.v1.FabridKeyResponse
 	(*FabridKeysResponse)(nil),                  // 4: proto.daemon.v1.FabridKeysResponse
-	(*experimental.FABRIDPolicyIdentifier)(nil), // 5: proto.control_plane.experimental.v1.FABRIDPolicyIdentifier
-	(*timestamppb.Timestamp)(nil),               // 6: google.protobuf.Timestamp
+	(*PolicyDescriptionRequest)(nil),            // 5: proto.daemon.v1.PolicyDescriptionRequest
+	(*PolicyDescriptionResponse)(nil),           // 6: proto.daemon.v1.PolicyDescriptionResponse
+	(*experimental.FABRIDPolicyIdentifier)(nil), // 7: proto.control_plane.experimental.v1.FABRIDPolicyIdentifier
+	(*timestamppb.Timestamp)(nil),               // 8: google.protobuf.Timestamp
 }
 var file_proto_daemon_v1_daemon_fabrid_proto_depIdxs = []int32{
 	1, // 0: proto.daemon.v1.FabridInfo.policies:type_name -> proto.daemon.v1.FabridPolicy
-	5, // 1: proto.daemon.v1.FabridPolicy.policy_identifier:type_name -> proto.control_plane.experimental.v1.FABRIDPolicyIdentifier
-	6, // 2: proto.daemon.v1.FabridKeyResponse.epoch_begin:type_name -> google.protobuf.Timestamp
-	6, // 3: proto.daemon.v1.FabridKeyResponse.epoch_end:type_name -> google.protobuf.Timestamp
+	7, // 1: proto.daemon.v1.FabridPolicy.policy_identifier:type_name -> proto.control_plane.experimental.v1.FABRIDPolicyIdentifier
+	8, // 2: proto.daemon.v1.FabridKeyResponse.epoch_begin:type_name -> google.protobuf.Timestamp
+	8, // 3: proto.daemon.v1.FabridKeyResponse.epoch_end:type_name -> google.protobuf.Timestamp
 	3, // 4: proto.daemon.v1.FabridKeysResponse.as_host_keys:type_name -> proto.daemon.v1.FabridKeyResponse
 	3, // 5: proto.daemon.v1.FabridKeysResponse.host_host_key:type_name -> proto.daemon.v1.FabridKeyResponse
 	6, // [6:6] is the sub-list for method output_type
@@ -507,6 +631,30 @@ func file_proto_daemon_v1_daemon_fabrid_proto_init() {
 				return nil
 			}
 		}
+		file_proto_daemon_v1_daemon_fabrid_proto_msgTypes[5].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*PolicyDescriptionRequest); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_proto_daemon_v1_daemon_fabrid_proto_msgTypes[6].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*PolicyDescriptionResponse); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
 	}
 	file_proto_daemon_v1_daemon_fabrid_proto_msgTypes[2].OneofWrappers = []interface{}{}
 	file_proto_daemon_v1_daemon_fabrid_proto_msgTypes[4].OneofWrappers = []interface{}{}
@@ -516,7 +664,7 @@ func file_proto_daemon_v1_daemon_fabrid_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: file_proto_daemon_v1_daemon_fabrid_proto_rawDesc,
 			NumEnums:      0,
-			NumMessages:   5,
+			NumMessages:   7,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/proto/daemon/v1/daemon.proto
+++ b/proto/daemon/v1/daemon.proto
@@ -47,6 +47,11 @@ service DaemonService {
     rpc DRKeyHostHost (DRKeyHostHostRequest) returns (DRKeyHostHostResponse) {}
     // FabridKeys returns the DRKeys for FABRID
     rpc FabridKeys (proto.daemon.v1.FabridKeysRequest) returns (proto.daemon.v1.FabridKeysResponse) {}
+    // PolicyDescription is used by a host inside the AS to request a policy description.
+    // Global policies are fetched from GitHub, non-global policies are handled by the
+    // control service.
+    rpc PolicyDescription(PolicyDescriptionRequest) returns
+        (PolicyDescriptionResponse) {}
 }
 
 message PathsRequest {

--- a/proto/daemon/v1/daemon_fabrid.proto
+++ b/proto/daemon/v1/daemon_fabrid.proto
@@ -65,3 +65,17 @@ message FabridKeysResponse {
     // The FABRID path key
     optional FabridKeyResponse host_host_key = 2;
 }
+
+message PolicyDescriptionRequest {
+    // Whether the policy is local or global
+    bool is_local = 1;
+    // The identifier for the policy
+    uint32 policy_identifier = 2;
+    // Remote ISD-AS if the policy identifier is local
+    uint64 isd_as = 3;
+}
+
+message PolicyDescriptionResponse {
+    // The string description of the policy.
+    string description = 1;
+}

--- a/scion/cmd/scion/BUILD.bazel
+++ b/scion/cmd/scion/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     srcs = [
         "address.go",
         "common.go",
+        "fabrid.go",
         "gendocs.go",
         "main.go",
         "observability.go",

--- a/scion/cmd/scion/fabrid.go
+++ b/scion/cmd/scion/fabrid.go
@@ -1,0 +1,169 @@
+// Copyright 2024 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v2"
+
+	"github.com/scionproto/scion/pkg/addr"
+	"github.com/scionproto/scion/pkg/daemon"
+	"github.com/scionproto/scion/pkg/private/serrors"
+	"github.com/scionproto/scion/private/app"
+	"github.com/scionproto/scion/private/app/flag"
+	"github.com/scionproto/scion/private/app/path"
+	"github.com/scionproto/scion/private/tracing"
+)
+
+func newFabrid(pather CommandPather) *cobra.Command {
+	var envFlags flag.SCIONEnvironment
+	var flags struct {
+		timeout  time.Duration
+		logLevel string
+		noColor  bool
+		tracer   string
+		format   string
+	}
+
+	var cmd = &cobra.Command{
+		Use:   "fabrid identifier [remote_as]",
+		Short: "Display FABRID policy information",
+		Args:  cobra.RangeArgs(1, 2),
+		Example: fmt.Sprintf(`  %[1]s fabrid G1001
+  %[1]s fabrid L1101 1-ff00:0:110
+  %[1]s fabrid L1101 1-ff00:0:110 --log.level debug'`, pather.CommandPath()),
+		Long: `'fabrid' fetches the description of a global or local FABRID policy.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args[0]) < 2 {
+				return serrors.New("Invalid identifier format", "identifier", args[0])
+			}
+			cs := path.DefaultColorScheme(flags.noColor)
+			identifierPrefix := args[0][0]
+			var isLocal bool
+			switch identifierPrefix {
+			case 'L':
+				isLocal = true
+			case 'G':
+				isLocal = false
+			default:
+				return serrors.New("invalid identifier prefix", "prefix", string(identifierPrefix))
+			}
+
+			identifier, err := strconv.ParseUint(args[0][1:], 10, 32)
+			if err != nil {
+				return serrors.New("invalid identifier format", "identifier", args[0])
+			}
+
+			if isLocal && len(args) == 1 {
+				return serrors.New("missing destination ISD-AS for local policy")
+			}
+			var dst addr.IA
+			if len(args) > 1 {
+				if !isLocal {
+					return serrors.New(
+						"unexpected argument. Global policies require no destination AS.")
+				}
+				dst, err = addr.ParseIA(args[1])
+				if err != nil {
+					return serrors.WrapStr("invalid destination ISD-AS", err)
+				}
+			}
+			if err = app.SetupLog(flags.logLevel); err != nil {
+				return serrors.WrapStr("setting up logging", err)
+			}
+			closer, err := setupTracer("fabrid", flags.tracer)
+			if err != nil {
+				return serrors.WrapStr("setting up tracing", err)
+			}
+			defer closer()
+
+			cmd.SilenceUsage = true
+
+			if err = envFlags.LoadExternalVars(); err != nil {
+				return err
+			}
+
+			daemonAddr := envFlags.Daemon()
+
+			span, traceCtx := tracing.CtxWith(context.Background(), "run")
+			defer span.Finish()
+			span.SetTag("dst.isd_as", dst)
+
+			ctx, cancel := context.WithTimeout(traceCtx, flags.timeout)
+			defer cancel()
+
+			var description string
+			daemonService := &daemon.Service{
+				Address: daemonAddr,
+			}
+			sdConn, err := daemonService.Connect(ctx)
+			if err != nil {
+				return serrors.WrapStr("connecting to the SCION Daemon", err, "addr", daemonAddr)
+			}
+			defer sdConn.Close()
+
+			description, err = sdConn.PolicyDescription(ctx, isLocal, uint32(identifier), &dst)
+			if err != nil {
+				return serrors.WrapStr("retrieving description from the SCION Daemon", err)
+			}
+			// Format and output the description based on the specified format
+			// Create a struct with the required fields and marshal it to the specified format
+			// for json and yaml:
+			output := struct {
+				Identifier  uint32
+				Local       bool
+				Description string
+			}{uint32(identifier), isLocal, description}
+			switch flags.format {
+			case "human":
+				if isLocal {
+					fmt.Printf("Policy %s@%s\n",
+						cs.LocalPolicy.Sprintf("L%d", identifier),
+						cs.Link.Sprintf("%s", dst))
+				} else {
+					fmt.Printf("Policy %s\n",
+						cs.GlobalPolicy.Sprintf("G%d", identifier))
+				}
+				fmt.Printf("  %s\n", description)
+			case "json":
+				enc := json.NewEncoder(os.Stdout)
+				enc.SetIndent("", "  ")
+				enc.SetEscapeHTML(false)
+				return enc.Encode(output)
+			case "yaml":
+				enc := yaml.NewEncoder(os.Stdout)
+				return enc.Encode(output)
+			}
+			// Output the description
+			return nil
+		},
+	}
+
+	envFlags.Register(cmd.Flags())
+	cmd.Flags().DurationVar(&flags.timeout, "timeout", 5*time.Second, "Timeout")
+	cmd.Flags().StringVar(&flags.format, "format", "human",
+		"Specify the output format (human|json|yaml)")
+	cmd.Flags().BoolVar(&flags.noColor, "no-color", false, "disable colored output")
+	cmd.Flags().StringVar(&flags.logLevel, "log.level", "", app.LogLevelUsage)
+	cmd.Flags().StringVar(&flags.tracer, "tracing.agent", "", "Tracing agent address")
+	return cmd
+}

--- a/scion/cmd/scion/main.go
+++ b/scion/cmd/scion/main.go
@@ -56,6 +56,7 @@ func main() {
 		newTraceroute(cmd),
 		newAddress(cmd),
 		newGendocs(cmd),
+		newFabrid(cmd),
 	)
 	// This Templatefunc allows use some escape characters for the rst
 	// documentation conversion without compromising the readability of the help


### PR DESCRIPTION
This PR adds the option to fetch policy descriptions to the `scion` CLI tool.  Largely based on https://github.com/jeltevanbommel/scionlab/pull/5

Concretely the CLI dials the local CS using the local SCION daemon. Then
-  for a requested FABRID Local policy: the local CS checks whether the policy is already known locally (either because it is a policy it owns, or it has recently requested the same identifier and it is cached) and returns the description. If it is not known to the local CS, the local CS dials the remote AS that has announced the FABRID Local policy identifier and requests the description. 
- for a requested FABRID global policy: the local SCION Daemon uses the global store of FABRID policies, which is configurable in the SCION Daemon configuration file, to request the policy description.

Other features:
- Pretty printing the result
- Add a special case for when we request a remote policy and it is a policy from our own AS.

Usage:
```
bin/scion fabrid G1100 --sciond $(./scion.sh sciond-addr 112)
bin/scion fabrid L1121 1-ff00:0:112 --sciond $(./scion.sh sciond-addr 112) --format human
bin/scion fabrid L1121 1-ff00:0:112 --sciond $(./scion.sh sciond-addr 112) --format json
```
